### PR TITLE
Add support of "pull/XX/files#diff-xxxxxxx" GH urls

### DIFF
--- a/pkg/github/handlers.go
+++ b/pkg/github/handlers.go
@@ -100,10 +100,13 @@ func handlePull(ctx context.Context, c *github.Client, owner, repo, ref, path, f
 	if err != nil {
 		return fmt.Errorf("invalid PR number %q", ref)
 	}
-	// presumably, if PR exists, then the files/commits tabs exist as well
 	_, _, err = c.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
 		return err
+	}
+	if fragment == "" {
+		// presumably, if PR exists, then the files/commits tabs exist as well
+		return nil
 	}
 
 	// Handle fragments


### PR DESCRIPTION
Unfortunately for url 'pull/XX/files#diff-xxxxxxx' I can't do much, the diff is not exposed via API.
So just test the PR exist is sufficient, which is done above

**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
