### PR TITLE
Fix GitHub regex: Correctly capture a URL from HTML

### DIFF
--- a/pkg/github/validator_test.go
+++ b/pkg/github/validator_test.go
@@ -145,6 +145,20 @@ func TestInternalLinkProcessor_ExtractLinks(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "correctly captures url from HTML",
+			line: `
+				<table>
+					<tr>
+						<td>your-ko</td>
+						<td>https://github.com/your-ko/link-validator</td>
+					  </tr>
+					</table>
+			`,
+			want: []string{
+				"https://github.com/your-ko/link-validator",
+			},
+		},
+		{
 			name: "Captures correctly with new lines, tabs and quotes",
 			line: `
 				"test.\n\nhttps://github.com/your-ko/link-validator\n\nhttps://github.com/your-ko/link-validator"

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -5,7 +5,7 @@ import "regexp"
 // this package contains no tests because the regexes are being tested in the corresponding packages in *_ExtractLinks tests
 
 // GitHub captures almost all GitHub urls
-var GitHub = regexp.MustCompile(`(?i)https://github\.(?:com|[a-z0-9-]+\.[a-z0-9.-]+)(?:/[^\s\x60\]~"\\]*[^\s.,:;!?()\[\]{}\x60~"\\])?`)
+var GitHub = regexp.MustCompile(`(?i)https://github\.(?:com|[a-z0-9-]+\.[a-z0-9.-]+)(?:/[^\s\x60\]~"\\<>]*[^\s.,:;!?()\[\]{}\x60~"\\<>])?`)
 
 // EnterpriseGitHub captures only enterprise GitHub urls and used to distinguish between public and enterprise.
 var EnterpriseGitHub = regexp.MustCompile(`github\.[a-z0-9-]+\.[a-z0-9.-]+`)


### PR DESCRIPTION
Correctly captures
```html
<table>
  <tr>
      <td>your-ko</td>
     <td>https://github.com/your-ko/link-validator</td>
  </tr>
</table>

```

**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
