### PR TITLE
GitHub validator ignores non API urls, but http validator captures them

### DIFF
--- a/pkg/github/validator.go
+++ b/pkg/github/validator.go
@@ -268,6 +268,9 @@ func (proc *LinkProcessor) ExtractLinks(line string) []string {
 		if strings.ContainsAny(raw, "[]{}()") {
 			continue // seems it is the templated url
 		}
+		if regex.GitHubExcluded.MatchString(raw) {
+			continue // skip non-API GitHub urls
+		}
 
 		// Filter out GitHub non-API URLs that shouldn't be validated here
 		hostname := strings.ToLower(u.Hostname())

--- a/pkg/github/validator_test.go
+++ b/pkg/github/validator_test.go
@@ -64,12 +64,23 @@ func TestInternalLinkProcessor_ExtractLinks(t *testing.T) {
 			},
 		},
 		{
-			name: "ignores subdomain uploads.* or api* ",
+			name: "ignores subdomain uploads.* or api*",
 			line: `test https://uploads.github.mycorp.com/org/repo/raw/main/image.png
 			       and external https://gitlab.mycorp.com/a/b
 			       and api https://api.github.mycorp.com/org/repo/tree/main/folder`,
 			want: nil,
 		},
+		{
+			name: "ignores non-API GitHub links",
+			line: `test
+				https://github.com/features/preview
+				https://raw.githubusercontent.com/your-ko/link-validator/refs/heads/main/README.md
+				https://github.blog/news-insights/product-news/lets-talk-about-github-actions
+				https://docs.github.com/en/actions
+				test`,
+			want: []string{},
+		},
+
 		{
 			name: "ignores non-matching schemes and hosts",
 			line: `scheme http://github.mycorp.com/org/repo/blob/main/README.md

--- a/pkg/http/validator.go
+++ b/pkg/http/validator.go
@@ -127,8 +127,8 @@ func (proc *LinkProcessor) ExtractLinks(line string) []string {
 		if strings.ContainsAny(raw, "[]{}()") {
 			continue // seems it is the templated url
 		}
-		if regex.GitHub.MatchString(raw) {
-			continue // skip GitHub urls
+		if regex.GitHub.MatchString(raw) && !regex.GitHubExcluded.MatchString(raw) {
+			continue // skip GitHub urls except for non-API ones
 		}
 		if regex.DataDog.MatchString(raw) {
 			continue // skip DataDog urls

--- a/pkg/http/validator_test.go
+++ b/pkg/http/validator_test.go
@@ -175,6 +175,21 @@ func TestExternalHttpLinkProcessor_ExtractLinks(t *testing.T) {
 				"https://google.com",
 			},
 		},
+		{
+			name: "captures non-API GitHub links",
+			line: `test
+				https://github.com/features/preview
+				https://raw.githubusercontent.com/your-ko/link-validator/refs/heads/main/README.md
+				https://github.blog/news-insights/product-news/lets-talk-about-github-actions
+				https://docs.github.com/en/actions
+				test`,
+			want: []string{
+				"https://github.com/features/preview",
+				"https://raw.githubusercontent.com/your-ko/link-validator/refs/heads/main/README.md",
+				"https://github.blog/news-insights/product-news/lets-talk-about-github-actions",
+				"https://docs.github.com/en/actions",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -20,3 +20,5 @@ var DotPattern = regexp.MustCompile(`\.{2,}`)
 
 // DataDog captures all app.datadoghq.com URLs including paths, query parameters, and fragments
 var DataDog = regexp.MustCompile(`(?i)https://app\.datadoghq\.com(?:/[^\s\x60\]~"\\]*[^\s.,:;!?()\[\]{}\x60~"\\])?`)
+
+var GitHubExcluded = regexp.MustCompile(`(?i)https://(?:github\.com/features|raw\.githubusercontent\.com|github\.blog|docs\.github\.com)(?:/[^\s\x60\]~"\\<>]*[^\s.,:;!?()\[\]{}\x60~"\\<>])?`)


### PR DESCRIPTION
non API GitHub calls should be processed by HTTP validator.

**Check list:**
- [x] Link related issue.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
