### PR TITLE
Fix http regex so urls are correctly captured from html

### DIFF
--- a/pkg/http/validator_test.go
+++ b/pkg/http/validator_test.go
@@ -190,6 +190,17 @@ func TestExternalHttpLinkProcessor_ExtractLinks(t *testing.T) {
 				"https://docs.github.com/en/actions",
 			},
 		},
+		{
+			name: "correctly processed links in html",
+			line: `test
+				<https://www.site.com/><br/><https://site2.com/><br/><https://site3.com/>
+				test`,
+			want: []string{
+				"https://www.site.com/",
+				"https://site2.com/",
+				"https://site3.com/",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -11,7 +11,7 @@ var GitHub = regexp.MustCompile(`(?i)https://(?:gist\.)?github\.(?:com|[a-z0-9-]
 var EnterpriseGitHub = regexp.MustCompile(`github\.[a-z0-9-]+\.[a-z0-9.-]+`)
 
 // Url captures all HTTPS URLs that looks valid.
-var Url = regexp.MustCompile(`https://[a-zA-Z0-9.\[\]{}-]+(?:/[^\s)]*[a-zA-Z0-9/#?&=_\[\]{}-]|/)?`)
+var Url = regexp.MustCompile(`https://[a-zA-Z0-9.\[\]{}-]+(?:/[^\s<>\])}]*[a-zA-Z0-9/#?&=_\[\]{}-]|/)?`)
 
 // LocalPath captures local Markdown links [text](path)
 var LocalPath = regexp.MustCompile(`\[[^]]*]\(((?:\.{1,2}/)*[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*(?:#[^)\s]*)?)\)`)


### PR DESCRIPTION
```html
<https://www.site.com/><br/><https://site2.com/><br/><https://site3.com/>
```

**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
