### PR TITLE
Checking for "not found" text is not good idea, http status is enough

### DIFF
--- a/pkg/http/validator.go
+++ b/pkg/http/validator.go
@@ -87,17 +87,13 @@ func (proc *LinkProcessor) Process(ctx context.Context, url string, _ string) er
 		defer func(Body io.ReadCloser) {
 			err := Body.Close()
 			if err != nil {
-				slog.With("error", err).Warn("can't close response body for %s", url)
+				slog.With("error", err).Warn("can't close response body", slog.String("url", url))
 			}
 		}(resp.Body)
 		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		if err != nil {
 			// we can't read body, something is off
 			return err
-		}
-		err = resp.Body.Close()
-		if err != nil {
-			slog.Info("error closing body: %s", slog.Any("error", err))
 		}
 
 		if len(bodyBytes) == 0 {


### PR DESCRIPTION
And if a server doesn't return for "Page Not Found" situation 404, it is misconfiguration on that server, the link-validator should not workaround it.

**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
