### PR TITLE
Fix teams handler for the case if the team is not specified

### DIFF
--- a/pkg/github/handlers.go
+++ b/pkg/github/handlers.go
@@ -564,6 +564,9 @@ func handleTeams(ctx context.Context, c client, owner, repo, ref, path, fragment
 	if err != nil {
 		return err
 	}
+	if ref == "" {
+		return nil
+	}
 	_, _, err = c.GetTeamBySlug(ctx, owner, ref)
 	return err
 }

--- a/pkg/github/handlers_test.go
+++ b/pkg/github/handlers_test.go
@@ -2146,6 +2146,15 @@ func Test_handleTeams(t *testing.T) {
 			},
 		},
 		{
+			name: "team is not specified",
+			args: args{"mycorp", "", "", "", ""},
+			setupMock: func(m *mockclient) {
+				org := &github.Organization{Name: github.Ptr("mycorp")}
+				resp := &github.Response{Response: &http.Response{StatusCode: http.StatusOK}}
+				m.EXPECT().getOrganization(mock.Anything, "mycorp").Return(org, resp, nil)
+			},
+		},
+		{
 			name: "team not found",
 			args: args{"mycorp", "", "sre", "", ""},
 			setupMock: func(m *mockclient) {

--- a/pkg/github/validator_test.go
+++ b/pkg/github/validator_test.go
@@ -1098,6 +1098,17 @@ func TestInternalLinkProcessor_ParseGitHubUrl(t *testing.T) {
 				ref:        "sre",
 			},
 		},
+		{
+			name: "github team",
+			url:  "https://github.mycorp.com/orgs/mycorp/teams",
+			want: &ghURL{
+				enterprise: true,
+				host:       "github.mycorp.com",
+				owner:      "mycorp",
+				typ:        "teams",
+				ref:        "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
in this case the validator just checks whether the org exists

**Check list:**
- [x] Link related issue.
- [ ] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.
