### PR TITLE
Fix setting different logLevels in the config file and the ENV variables.

### DIFF
--- a/internal/link-validator/logger.go
+++ b/internal/link-validator/logger.go
@@ -16,9 +16,13 @@ type CustomHandler struct {
 }
 
 func InitLogger(cfg *config.Config) *CustomHandler {
+	logLevel := slog.LevelInfo // default
+	if cfg.LogLevel != nil {
+		logLevel = *cfg.LogLevel
+	}
 	return &CustomHandler{
 		writer: os.Stderr,
-		level:  cfg.LogLevel.Level(),
+		level:  logLevel.Level(),
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,7 @@ func loadFromReader(reader io.Reader) (*Config, error) {
 }
 
 func readFromEnv() (*Config, error) {
-	cfg := Default()
+	cfg := &Config{}
 
 	// Only set values if environment variables are actually set
 	if corpURL := GetEnv("CORP_URL", ""); corpURL != "" {
@@ -77,7 +77,7 @@ func readFromEnv() (*Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("can't parse logLevel: '%s', error: %w", LogLevelStr, err)
 		}
-		cfg.LogLevel = slogLevel
+		cfg.LogLevel = &slogLevel
 	}
 	if fileMasks := GetEnv("FILE_MASKS", ""); fileMasks != "" {
 		cfg.FileMasks = strings.Split(strings.TrimSuffix(fileMasks, ","), ",")
@@ -158,7 +158,9 @@ func (cfg *Config) merge(merge *Config) {
 	if merge.Timeout != 0 {
 		cfg.Timeout = merge.Timeout
 	}
-	cfg.LogLevel = merge.LogLevel
+	if merge.LogLevel != nil {
+		cfg.LogLevel = merge.LogLevel
+	}
 	cfg.FileMasks = mergeSlices(cfg.FileMasks, merge.FileMasks)
 	cfg.Files = mergeSlices(cfg.Files, merge.Files)
 	cfg.Exclude = mergeSlices(cfg.Exclude, merge.Exclude)

--- a/pkg/config/model.go
+++ b/pkg/config/model.go
@@ -11,7 +11,7 @@ type validator interface {
 }
 
 type Config struct {
-	LogLevel   slog.Level       `yaml:"logLevel"`
+	LogLevel   *slog.Level      `yaml:"logLevel,omitempty"`
 	FileMasks  []string         `yaml:"fileMasks"`
 	Files      []string         `yaml:"files"`
 	Exclude    []string         `yaml:"exclude"`
@@ -97,8 +97,9 @@ func (v ValidatorsConfig) validate() []error {
 
 // Default generates default config
 func Default() *Config {
+	defaultLogLevel := slog.LevelInfo
 	return &Config{
-		LogLevel:   slog.LevelInfo,
+		LogLevel:   &defaultLogLevel,
 		LookupPath: ".",
 		FileMasks:  []string{"*.md"},
 		Timeout:    3 * time.Second,


### PR DESCRIPTION
Before: if logLevel wasn't set in the env variables, then it was assumed to be INFO and it was overriding the config value.

**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
