### PR TITLE
Fix enterprise GitHub client using wrong auth token

### DIFF
--- a/pkg/github/validator.go
+++ b/pkg/github/validator.go
@@ -100,8 +100,8 @@ func New(cfg *config.Config) (*LinkProcessor, error) {
 		host,
 		strings.ReplaceAll(host, "https://", "https://uploads."),
 	)}
-	if cfg.Validators.GitHub.PAT != "" {
-		opts = append(opts, github.WithAuthToken(cfg.Validators.GitHub.PAT))
+	if cfg.Validators.GitHub.CorpPAT != "" {
+		opts = append(opts, github.WithAuthToken(cfg.Validators.GitHub.CorpPAT))
 	}
 
 	corpClient, err := github.NewClient(opts...)


### PR DESCRIPTION
Fixes a regression introduced in 2.3.4 where the GitHub Enterprise (corp) client was authenticated with PAT (the public GitHub token) instead of CorpPAT, causing all  enterprise links to fail with 401 Bad credentials.

The refactor to go-github v87's functional options API accidentally used cfg.Validators.GitHub.PAT when building the corp client options, discarding CorpPAT entirely. This broke every enterprise link validation silently introduced in the v85→v87 upgrade.


**Check list:**
- [ ] Link related issue.
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.
